### PR TITLE
update so when we fetch asap it actually gets added to cache

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -122,7 +122,7 @@ const Home: NextPage = () => {
   const { isLoaded: userLoaded, isSignedIn } = useUser();
 
   // Start fetching asap
-  api.posts.getAll.useQuery();
+  api.posts.infiniteScroll.useInfiniteQuery({ limit: 25 });
 
   // Return empty div if user isn't loaded
   if (!userLoaded) return <div />;


### PR DESCRIPTION
Correct me if I'm wrong, but I believe my last PR would miss the cache on the initial fetch because we are hitting a different endpoint. I've updated that home component fetch to the new infinite scroll endpoint I made.